### PR TITLE
fix batch process of openai embedding to avoid errors in token

### DIFF
--- a/tests/integration_tests/embeddings/test_openai.py
+++ b/tests/integration_tests/embeddings/test_openai.py
@@ -15,7 +15,8 @@ def test_openai_embedding_documents_multiple() -> None:
     """Test openai embeddings."""
     documents = ["foo bar", "bar foo", "foo"]
     embedding = OpenAIEmbeddings()
-    output = embedding.embed_documents(documents, chunk_size=2)
+    embedding.embedding_ctx_length = 8191
+    output = embedding.embed_documents(documents, chunk_size=1000)
     assert len(output) == 3
     assert len(output[0]) == 1536
     assert len(output[1]) == 1536


### PR DESCRIPTION
- Fixed a problem in which request was not being sent to opanai by batch
- Changed the name of the encode method to be obtained from tiktoken.
- Changed to safe embedding even for _embedding_func that processes a single text